### PR TITLE
fix: make writeRaw and resize fire-and-forget to prevent IPC timeouts

### DIFF
--- a/packages/pty-manager/src/bun-compat.ts
+++ b/packages/pty-manager/src/bun-compat.ts
@@ -524,10 +524,12 @@ export class BunCompatiblePTYManager extends EventEmitter {
    */
   async writeRaw(id: string, data: string): Promise<void> {
     await this.waitForReady();
-
     this.sendCommand({ cmd: 'writeRaw', id, data });
-
-    await this.createPending(`writeRaw:${id}`);
+    // Fire-and-forget — writeRaw pushes bytes to the terminal and
+    // doesn't need an ACK.  Awaiting createPending caused timeouts
+    // when overlapping calls for the same session collided on the
+    // pending key (`writeRaw:${id}`), since the worker ACK only
+    // carries cmd+id with no sequence number.
   }
 
   /**
@@ -546,16 +548,14 @@ export class BunCompatiblePTYManager extends EventEmitter {
    */
   async resize(id: string, cols: number, rows: number): Promise<void> {
     await this.waitForReady();
-
     this.sendCommand({ cmd: 'resize', id, cols, rows });
-
     const session = this.sessions.get(id);
     if (session) {
       session.cols = cols;
       session.rows = rows;
     }
-
-    await this.createPending(`resize:${id}`);
+    // Fire-and-forget — rapid resize events from the UI collide on
+    // the pending key (`resize:${id}`) causing spurious timeouts.
   }
 
   /**


### PR DESCRIPTION
## Summary
- `writeRaw` and `resize` in `BunCompatiblePTYManager` awaited `createPending` with keys like `writeRaw:${sessionId}` and `resize:${sessionId}`
- When overlapping calls hit the same session (UI input + orchestrator task delivery, or rapid ResizeObserver events), the pending Map entry was silently overwritten — the first call's promise never resolved, causing 30s timeout errors
- Made both operations fire-and-forget: send the command to the worker but don't await ACK, since writing bytes to a PTY and resizing don't need round-trip confirmation
- Worker still ACKs harmlessly; `resolvePending` just won't find a matching entry

## Test plan
- [x] 226 existing tests pass (3 pre-existing failures on main, unrelated)
- [ ] Run milady with xterm drawer open — no more `Operation writeRaw timed out` errors
- [ ] Verify terminal input still works (type in drawer, agent receives it)
- [ ] Verify resize still works (resize browser window, terminal reflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)