### PR TITLE
feat: disableToolsFlag config option for Claude preset

### DIFF
--- a/packages/coding-agent-adapters/src/approval-presets.ts
+++ b/packages/coding-agent-adapters/src/approval-presets.ts
@@ -57,6 +57,31 @@ export interface ApprovalConfig {
   summary: string;
 }
 
+/**
+ * Per-adapter options that fine-tune the generated approval config without
+ * changing the preset semantics themselves.
+ */
+export interface ClaudePresetOptions {
+  /**
+   * When set, omit the `--tools <list>` flag from the generated `cliFlags`
+   * for the autonomous preset.
+   *
+   * The `--tools` list is built from `CLAUDE_TOOL_CATEGORIES`, whose entries
+   * (Bash, Edit, Write, Read, Grep, Glob, ...) are the tool names exposed by
+   * Claude Code's developer-tier tool registry. When `claude` is run against
+   * the claude.ai OAuth tier (an Anthropic subscription account, no
+   * `ANTHROPIC_API_KEY`) the available tool names differ, so passing this
+   * list filters the model down to a tiny read-only subset instead of
+   * unlocking everything. Set `disableToolsFlag: true` to skip the filter
+   * entirely; `--dangerously-skip-permissions` still bypasses approval.
+   */
+  disableToolsFlag?: boolean;
+}
+
+export interface GenerateApprovalConfigOptions {
+  claude?: ClaudePresetOptions;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
@@ -270,7 +295,8 @@ function getToolsForCategories(
 }
 
 export function generateClaudeApprovalConfig(
-  preset: ApprovalPreset
+  preset: ApprovalPreset,
+  options: ClaudePresetOptions = {}
 ): ApprovalConfig {
   const def = getPresetDefinition(preset);
 
@@ -317,8 +343,14 @@ export function generateClaudeApprovalConfig(
       );
       _autonomousSandboxWarningLogged = true;
     }
-    const allTools = Object.keys(CLAUDE_TOOL_CATEGORIES);
-    cliFlags.push('--tools', allTools.join(','));
+    // Skip `--tools <list>` when the caller requests it. The CLAUDE_TOOL_CATEGORIES
+    // names are the dev-tier registry; on the claude.ai OAuth tier they do not
+    // match the registry and passing them filters tools down to a read-only
+    // subset. See ClaudePresetOptions.disableToolsFlag.
+    if (!options.disableToolsFlag) {
+      const allTools = Object.keys(CLAUDE_TOOL_CATEGORIES);
+      cliFlags.push('--tools', allTools.join(','));
+    }
   }
 
   return {
@@ -523,11 +555,12 @@ export function generateHermesApprovalConfig(
 
 export function generateApprovalConfig(
   adapterType: AdapterType,
-  preset: ApprovalPreset
+  preset: ApprovalPreset,
+  options: GenerateApprovalConfigOptions = {}
 ): ApprovalConfig {
   switch (adapterType) {
     case 'claude':
-      return generateClaudeApprovalConfig(preset);
+      return generateClaudeApprovalConfig(preset, options.claude);
     case 'gemini':
       return generateGeminiApprovalConfig(preset);
     case 'codex':

--- a/packages/coding-agent-adapters/src/index.ts
+++ b/packages/coding-agent-adapters/src/index.ts
@@ -44,6 +44,8 @@ export { AiderAdapter } from './aider-adapter';
 export type {
   ApprovalConfig,
   ApprovalPreset,
+  ClaudePresetOptions,
+  GenerateApprovalConfigOptions,
   PresetDefinition,
   RiskLevel,
   ToolCategory,

--- a/packages/coding-agent-adapters/tests/approval-presets.test.ts
+++ b/packages/coding-agent-adapters/tests/approval-presets.test.ts
@@ -155,6 +155,14 @@ describe('Approval Presets', () => {
         generateApprovalConfig('unknown' as never, 'standard')
       ).toThrow('Unknown adapter type');
     });
+
+    it('forwards claude options to generateClaudeApprovalConfig', () => {
+      const config = generateApprovalConfig('claude', 'autonomous', {
+        claude: { disableToolsFlag: true },
+      });
+      expect(config.cliFlags).not.toContain('--tools');
+      expect(config.cliFlags).toContain('--dangerously-skip-permissions');
+    });
   });
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -197,6 +205,21 @@ describe('Approval Presets', () => {
       expect(settings.sandbox?.enabled).toBe(true);
       expect(settings.sandbox?.autoAllowBashIfSandboxed).toBe(true);
       expect(settings.permissions.allow).toContain('Bash');
+      expect(config.cliFlags).toContain('--tools');
+    });
+
+    it('autonomous with disableToolsFlag: omits --tools, keeps --dangerously-skip-permissions', () => {
+      const config = generateClaudeApprovalConfig('autonomous', {
+        disableToolsFlag: true,
+      });
+      expect(config.cliFlags).toContain('--dangerously-skip-permissions');
+      expect(config.cliFlags).not.toContain('--tools');
+    });
+
+    it('autonomous with disableToolsFlag: false behaves like default (adds --tools)', () => {
+      const config = generateClaudeApprovalConfig('autonomous', {
+        disableToolsFlag: false,
+      });
       expect(config.cliFlags).toContain('--tools');
     });
 


### PR DESCRIPTION
## Summary

Add an optional `disableToolsFlag` config option to the Claude autonomous preset so callers can omit the `--tools <list>` CLI flag from the generated `cliFlags`.

## Why

The `--tools` list emitted by `generateClaudeApprovalConfig` for the `autonomous` preset is built from `CLAUDE_TOOL_CATEGORIES`:

```ts
const allTools = Object.keys(CLAUDE_TOOL_CATEGORIES);
cliFlags.push('--tools', allTools.join(','));
```

Those names (Bash, Edit, Write, Read, Grep, Glob, WebFetch, ...) are the tool names exposed by Claude Code's **developer-tier** tool registry. They work when `claude` runs against the Anthropic API with an `ANTHROPIC_API_KEY`.

When `claude` runs against the **claude.ai OAuth tier** instead (an Anthropic subscription account — no `ANTHROPIC_API_KEY`, just `claude /login`), the registry differs. Passing the dev-tier names via `--tools` doesn't unlock those tools — it filters the model down to whatever subset of the passed names *does* exist in the OAuth-tier registry, which in practice is a tiny read-only set (`Read`, `Grep`, `Glob`, `AskUserQuestion`, `TodoWrite`). The agent ends up unable to write files, run shell commands, or use any of the tools the autonomous preset is supposed to enable.

Skipping `--tools` entirely lets `claude` expose its actual default toolset for whichever tier it's running on; `--dangerously-skip-permissions` still bypasses approval.

This has been hitting downstream consumers (Milady / elizaOS) running `coding-agent-adapters` against subscription-tier `claude` installs, who currently work around it by post-install patching `node_modules/coding-agent-adapters/dist/index.{js,cjs}` to strip the `--tools` push. A first-class config knob removes the need for that bridge patch.

## Surface area

- New `ClaudePresetOptions { disableToolsFlag?: boolean }` — exported.
- New `GenerateApprovalConfigOptions { claude?: ClaudePresetOptions }` — exported.
- `generateClaudeApprovalConfig(preset, options?)` now accepts options; the `--tools` push for autonomous is gated on `!options.disableToolsFlag`. Default behavior is unchanged.
- `generateApprovalConfig(adapterType, preset, options?)` forwards `options.claude` to the Claude generator. The third arg is optional and defaults to `{}`, so existing callers don't need to change anything.
- Three new tests in `tests/approval-presets.test.ts` covering `disableToolsFlag=true` omits `--tools` (but keeps `--dangerously-skip-permissions`), `disableToolsFlag=false` matches default behavior, and the dispatcher forwards options.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — all 659 tests pass (656 existing + 3 new)
- [x] `pnpm build` — tsup ESM/CJS/DTS all build clean
- [x] `npx biome check` clean on all modified files
- [ ] Verified against claude.ai OAuth tier in downstream consumer (Milady)

🤖 Generated with [Claude Code](https://claude.com/claude-code)