### PR TITLE
feat(coding-agent-adapters): add first-class OpencodeAdapter

### DIFF
--- a/packages/coding-agent-adapters/src/approval-presets.ts
+++ b/packages/coding-agent-adapters/src/approval-presets.ts
@@ -536,9 +536,54 @@ export function generateApprovalConfig(
       return generateAiderApprovalConfig(preset);
     case 'hermes':
       return generateHermesApprovalConfig(preset);
+    case 'opencode':
+      return generateOpencodeApprovalConfig(preset);
     default:
       throw new Error(`Unknown adapter type: ${adapterType}`);
   }
+}
+
+/**
+ * OpenCode approval-preset → CLI flag mapping.
+ *
+ * OpenCode has a single permission switch: `--dangerously-skip-permissions`
+ * (a flag of the `run` subcommand). Either you accept all tool actions
+ * unsupervised or you don't. The readonly / standard / permissive
+ * presets map to "no flag" (opencode falls back to its own interactive
+ * permission prompts); only `autonomous` opts into the bypass.
+ *
+ * Tools are not declared explicitly to opencode at spawn time — it picks
+ * them up from its built-in registry and the loaded plugins. `tools: {}`
+ * is kept for shape-consistency with the other adapters.
+ */
+export function generateOpencodeApprovalConfig(
+  preset: ApprovalPreset
+): ApprovalConfig {
+  const cliFlags: string[] = [];
+  let summary: string;
+  switch (preset) {
+    case 'autonomous':
+      cliFlags.push('--dangerously-skip-permissions');
+      summary =
+        'OpenCode: all tool actions auto-approved (--dangerously-skip-permissions)';
+      break;
+    case 'readonly':
+      summary = 'OpenCode: interactive permissions (read-heavy session)';
+      break;
+    case 'standard':
+      summary = 'OpenCode: interactive permissions (standard session)';
+      break;
+    case 'permissive':
+      summary = 'OpenCode: interactive permissions (permissive session)';
+      break;
+  }
+  return {
+    preset,
+    cliFlags,
+    workspaceFiles: [],
+    envVars: {},
+    summary,
+  };
 }
 
 export function listPresets(): PresetDefinition[] {

--- a/packages/coding-agent-adapters/src/base-coding-adapter.ts
+++ b/packages/coding-agent-adapters/src/base-coding-adapter.ts
@@ -19,7 +19,13 @@ import {
 /**
  * Supported adapter types
  */
-export type AdapterType = 'claude' | 'gemini' | 'codex' | 'aider' | 'hermes';
+export type AdapterType =
+  | 'claude'
+  | 'gemini'
+  | 'codex'
+  | 'aider'
+  | 'hermes'
+  | 'opencode';
 
 /**
  * Authentication status for a CLI agent's subscription/login.

--- a/packages/coding-agent-adapters/src/index.ts
+++ b/packages/coding-agent-adapters/src/index.ts
@@ -84,6 +84,7 @@ export { ClaudeAdapter } from './claude-adapter';
 export { CodexAdapter } from './codex-adapter';
 export { GeminiAdapter } from './gemini-adapter';
 export { HermesAdapter } from './hermes-adapter';
+export { OpencodeAdapter } from './opencode-adapter';
 export type { AdapterPatterns } from './pattern-loader';
 // Pattern loading (dynamic patterns from adapter-monitor, with baseline fallback)
 export {
@@ -101,6 +102,7 @@ import { ClaudeAdapter } from './claude-adapter';
 import { CodexAdapter } from './codex-adapter';
 import { GeminiAdapter } from './gemini-adapter';
 import { HermesAdapter } from './hermes-adapter';
+import { OpencodeAdapter } from './opencode-adapter';
 
 /**
  * Create instances of all available adapters
@@ -112,6 +114,7 @@ export function createAllAdapters() {
     new CodexAdapter(),
     new AiderAdapter(),
     new HermesAdapter(),
+    new OpencodeAdapter(),
   ];
 }
 
@@ -127,12 +130,14 @@ export const ADAPTER_TYPES: Record<
   | typeof CodexAdapter
   | typeof AiderAdapter
   | typeof HermesAdapter
+  | typeof OpencodeAdapter
 > = {
   claude: ClaudeAdapter,
   gemini: GeminiAdapter,
   codex: CodexAdapter,
   aider: AiderAdapter,
   hermes: HermesAdapter,
+  opencode: OpencodeAdapter,
 };
 
 /**

--- a/packages/coding-agent-adapters/src/opencode-adapter.ts
+++ b/packages/coding-agent-adapters/src/opencode-adapter.ts
@@ -1,0 +1,336 @@
+/**
+ * OpenCode CLI Adapter
+ *
+ * Adapter for the OpenCode CLI (https://opencode.ai). OpenCode is a
+ * provider-agnostic coding agent — it speaks OpenAI's chat-completions
+ * protocol against any compatible endpoint (Anthropic, OpenAI, Cerebras,
+ * OpenRouter, Groq, Together, DeepSeek, Ollama, vLLM, etc.) plus a
+ * native Anthropic backend. Configuration is supplied to the binary via
+ * the `OPENCODE_CONFIG_CONTENT` environment variable (a JSON object that
+ * defines providers + the chosen model). The orchestrator constructs
+ * that JSON from the user's standard provider env keys.
+ *
+ * Workspace-file convention matches Codex: `AGENTS.md` at the workdir
+ * root is auto-loaded as project instructions on startup.
+ *
+ * Source: https://github.com/sst/opencode
+ */
+
+import type {
+  BlockingPromptDetection,
+  LoginDetection,
+  ParsedOutput,
+  SpawnConfig,
+} from 'adapter-types';
+import {
+  type AgentCredentials,
+  type AgentFileDescriptor,
+  BaseCodingAdapter,
+  type InstallationInfo,
+  type ModelRecommendations,
+} from './base-coding-adapter';
+
+export class OpencodeAdapter extends BaseCodingAdapter {
+  readonly adapterType = 'opencode';
+  readonly displayName = 'OpenCode';
+
+  /**
+   * OpenCode's TUI is light (no full-screen ratatui-style status bar),
+   * so a short settle is sufficient — matches Gemini-CLI's 300ms baseline.
+   */
+  override readonly readySettleMs: number = 300;
+
+  readonly installation: InstallationInfo = {
+    command: 'curl -fsSL https://opencode.ai/install | bash',
+    alternatives: [
+      'npm install -g opencode-ai',
+      'brew install sst/tap/opencode',
+    ],
+    docsUrl: 'https://opencode.ai/docs',
+  };
+
+  getWorkspaceFiles(): AgentFileDescriptor[] {
+    return [
+      {
+        relativePath: 'AGENTS.md',
+        description:
+          'Project-level instructions auto-loaded by OpenCode on startup (same convention as Codex).',
+        autoLoaded: true,
+        type: 'memory',
+        format: 'markdown',
+      },
+      {
+        relativePath: 'opencode.json',
+        description:
+          'Optional workspace-scoped OpenCode config (provider/model overrides for this project).',
+        autoLoaded: true,
+        type: 'config',
+        format: 'json',
+      },
+    ];
+  }
+
+  getRecommendedModels(credentials?: AgentCredentials): ModelRecommendations {
+    // Anthropic key → Claude (OpenCode's native backend). Otherwise prefer
+    // a non-reasoning OpenAI-spec model so reasoning_effort tuning isn't
+    // required for the default to work.
+    if (credentials?.anthropicKey) {
+      return {
+        powerful: 'anthropic/claude-opus-4-7',
+        fast: 'anthropic/claude-haiku-4-5',
+      };
+    }
+    return {
+      powerful: 'openai/gpt-4o',
+      fast: 'openai/gpt-4o-mini',
+    };
+  }
+
+  getCommand(): string {
+    return 'opencode';
+  }
+
+  getArgs(config: SpawnConfig): string[] {
+    // OpenCode TUI launches with bare `opencode`. The `run` subcommand
+    // is non-interactive: it consumes the message as the prompt, drives
+    // a single agent loop, and exits. `--dangerously-skip-permissions`
+    // is a `run`-subcommand flag (NOT top-level), so it must come AFTER
+    // `run` — verified live with opencode 1.14.x.
+    if (this.isInteractive(config)) {
+      return [];
+    }
+    const args = ['run', '--dangerously-skip-permissions'];
+    // The caller may pass the task as `config.initialTask`; we don't
+    // append it here because pty-manager's PTYManager.spawn flow uses
+    // the initialTask separately. If the orchestrator wants the task on
+    // the command line, it can wrap via the `toOpencodeCommand` helper.
+    return args;
+  }
+
+  getEnv(config: SpawnConfig): Record<string, string> {
+    const env: Record<string, string> = {};
+    const credentials = this.getCredentials(config);
+
+    // The orchestrator passes a fully-baked OpenCode config (JSON
+    // describing the chosen provider + apiKey + model) via the
+    // `OPENCODE_CONFIG_CONTENT` env var. The opencode binary reads that
+    // env var ahead of any local config files. The orchestrator's
+    // `buildOpencodeSpawnConfig` helper synthesizes this from whatever
+    // provider env vars the user has configured (CEREBRAS_API_KEY,
+    // OPENROUTER_API_KEY, etc.).
+    if (config.env?.OPENCODE_CONFIG_CONTENT) {
+      env.OPENCODE_CONFIG_CONTENT = config.env.OPENCODE_CONFIG_CONTENT;
+    }
+
+    // Suppress the auto-update check and terminal-title hijack so PTY
+    // output stays clean for the orchestrator's parser.
+    env.OPENCODE_DISABLE_AUTOUPDATE = '1';
+    env.OPENCODE_DISABLE_TERMINAL_TITLE = '1';
+
+    // Forward provider API keys for users who prefer letting OpenCode
+    // discover them natively (instead of via OPENCODE_CONFIG_CONTENT).
+    // OpenCode's per-provider env-key conventions match the providers'
+    // own docs.
+    if (credentials.anthropicKey) {
+      env.ANTHROPIC_API_KEY = credentials.anthropicKey;
+    }
+    if (credentials.openaiKey) {
+      env.OPENAI_API_KEY = credentials.openaiKey;
+      if (credentials.openaiBaseUrl) {
+        env.OPENAI_BASE_URL = credentials.openaiBaseUrl;
+      }
+    }
+    if (credentials.googleKey) {
+      env.GOOGLE_API_KEY = credentials.googleKey;
+      env.GEMINI_API_KEY = credentials.googleKey;
+    }
+
+    return env;
+  }
+
+  /**
+   * OpenCode does not display its own login prompts when an API key is
+   * pre-supplied (either via OPENCODE_CONFIG_CONTENT or a provider env
+   * var). The bare `opencode auth` CLI exists for interactive setup, but
+   * orchestrator-managed sessions never need it — credentials are
+   * injected via env at spawn time.
+   *
+   * Auth-required signals are limited to error banners that surface
+   * when an inbound request is rejected (401 / 403 / "invalid api key").
+   */
+  detectLogin(output: string): LoginDetection {
+    const stripped = this.stripAnsi(output);
+
+    if (
+      /no.?provider.?configured|opencode.?auth.?login/i.test(stripped) ||
+      /missing.?api.?key|api.?key.?not.?found/i.test(stripped)
+    ) {
+      return {
+        required: true,
+        type: 'api_key',
+        instructions:
+          'OpenCode requires a provider API key. Set OPENCODE_CONFIG_CONTENT or one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, CEREBRAS_API_KEY, OPENROUTER_API_KEY.',
+      };
+    }
+
+    if (
+      /401|403|unauthorized|invalid.?api.?key/i.test(stripped) &&
+      /opencode|provider/i.test(stripped)
+    ) {
+      return {
+        required: true,
+        type: 'api_key',
+        instructions:
+          'OpenCode provider rejected credentials. Verify the API key for the selected provider.',
+      };
+    }
+
+    return { required: false };
+  }
+
+  /**
+   * `--dangerously-skip-permissions` on `opencode run` short-circuits the
+   * usual permission UI, so during normal orchestrator-spawned sessions
+   * the adapter rarely encounters blocking prompts. The patterns below
+   * cover the residual cases (interactive sessions, or provider auth
+   * surfacing mid-run).
+   */
+  detectBlockingPrompt(output: string): BlockingPromptDetection {
+    const stripped = this.stripAnsi(output);
+
+    const loginDetection = this.detectLogin(output);
+    if (loginDetection.required) {
+      return {
+        detected: true,
+        type: 'login',
+        prompt: loginDetection.instructions,
+        canAutoRespond: false,
+        instructions: loginDetection.instructions,
+      };
+    }
+
+    // Permission request from the agent — only appears WITHOUT
+    // --dangerously-skip-permissions. Looks like: "! permission requested:
+    // external_directory (/home/user/*); auto-rejecting"
+    if (/permission requested:\s+\S+/i.test(stripped)) {
+      return {
+        detected: true,
+        type: 'permission',
+        prompt: 'OpenCode permission request',
+        canAutoRespond: false,
+        instructions:
+          'OpenCode is asking permission for a tool action. Re-spawn with --dangerously-skip-permissions if this is automation.',
+      };
+    }
+
+    return super.detectBlockingPrompt(output);
+  }
+
+  detectLoading(output: string): boolean {
+    const stripped = this.stripAnsi(output);
+    const tail = stripped.slice(-600);
+
+    // Active agent loop indicator emitted at the top of every run:
+    // "> build · gpt-oss-120b" (provider · model). Stays visible while
+    // the agent is iterating. NOTE: BaseCodingAdapter.stripAnsi strips
+    // `← → ↑ ↓` as TUI decoration, so we can't rely on opencode's
+    // arrow-prefixed tool-call status lines as a separate signal — the
+    // build-header line is sufficient on its own.
+    if (/^>\s+(build|chat|plan|run)\s+·\s+\S+/im.test(tail)) {
+      return true;
+    }
+
+    // Tool-call status lines after stripAnsi look like " Write /path"
+    // (the `←` arrow is stripped, leaving a leading space). The verb
+    // word is the durable signal.
+    if (
+      /(?:^|\n)\s+(?:Read|Write|Edit|Bash|Glob|Grep|Run|Tool)\s+\S+/.test(tail)
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  detectTaskComplete(output: string): boolean {
+    const stripped = this.stripAnsi(output);
+    if (!stripped.trim()) return false;
+
+    // In `run` mode the session exits naturally after the agent loop
+    // completes — the orchestrator's process-exit detection handles the
+    // strong signal. As a soft signal, the absence of an active build
+    // line PLUS the presence of a terminal response is sufficient.
+    if (this.detectLoading(stripped)) {
+      return false;
+    }
+
+    // Terminal session finished: opencode emits "Wrote file successfully."
+    // or a final assistant response when everything completed normally.
+    if (
+      /Wrote file successfully\.|^Done\.?$|^Finished\.?$/im.test(stripped)
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  detectReady(output: string): boolean {
+    const stripped = this.stripAnsi(output);
+    const tail = stripped.slice(-400);
+
+    if (!tail.trim()) return false;
+
+    if (this.detectLoading(tail)) {
+      return false;
+    }
+
+    // Interactive `opencode` TUI prompts with `>` followed by a cursor.
+    // In `run` mode this rarely appears (the process exits instead).
+    if (/(?:^|\n)\s*>\s*$/m.test(tail)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  parseOutput(output: string): ParsedOutput | null {
+    const stripped = this.stripAnsi(output);
+    const complete = this.detectTaskComplete(stripped);
+    if (!complete) {
+      return null;
+    }
+
+    // OpenCode's `run` mode prints the agent's final reply as the last
+    // non-tool-call block before the process exits. Strip the "> build"
+    // header and any "← Write /path" tool lines to isolate user-facing
+    // text.
+    const content = stripped
+      .split('\n')
+      .filter((line) => {
+        if (/^>\s+(build|chat|plan|run)\s+·/i.test(line)) return false;
+        if (/^[←→$]\s+(Read|Write|Edit|Bash|Glob|Grep|Run|Tool)/i.test(line))
+          return false;
+        if (/^Wrote file successfully\.?$/i.test(line)) return false;
+        return true;
+      })
+      .join('\n')
+      .trim();
+
+    return {
+      type: this.containsQuestion(content) ? 'question' : 'response',
+      content,
+      isComplete: true,
+      isQuestion: this.containsQuestion(content),
+      metadata: { raw: output },
+    };
+  }
+
+  getPromptPattern(): RegExp {
+    return /(?:^|\n)\s*>\s*$/m;
+  }
+
+  getHealthCheckCommand(): string {
+    return 'opencode --version';
+  }
+}

--- a/packages/coding-agent-adapters/src/opencode-adapter.ts
+++ b/packages/coding-agent-adapters/src/opencode-adapter.ts
@@ -100,10 +100,17 @@ export class OpencodeAdapter extends BaseCodingAdapter {
       return [];
     }
     const args = ['run', '--dangerously-skip-permissions'];
-    // The caller may pass the task as `config.initialTask`; we don't
-    // append it here because pty-manager's PTYManager.spawn flow uses
-    // the initialTask separately. If the orchestrator wants the task on
-    // the command line, it can wrap via the `toOpencodeCommand` helper.
+    // OpenCode `run` mode requires the task as a positional argument
+    // (it does NOT read from stdin like Claude / Codex). Callers pass
+    // the prompt via `config.adapterConfig.initialPrompt` (mirroring
+    // codex's exec-mode convention). Without this arg the session
+    // spawns idle.
+    const initialPrompt = (
+      config.adapterConfig as { initialPrompt?: unknown } | undefined
+    )?.initialPrompt;
+    if (typeof initialPrompt === 'string' && initialPrompt.trim()) {
+      args.push(initialPrompt.trim());
+    }
     return args;
   }
 

--- a/packages/coding-agent-adapters/src/pattern-loader.ts
+++ b/packages/coding-agent-adapters/src/pattern-loader.ts
@@ -136,6 +136,27 @@ const BASELINE_PATTERNS: Record<AdapterType, AdapterPatterns> = {
     exit: ['Goodbye! ⚕'],
     source: 'baseline',
   },
+  opencode: {
+    // OpenCode emits a "> build · <model>" header at the top of every
+    // session (interactive TUI prints `> ` as the input prompt; `run`
+    // mode shows the build header then streams agent output).
+    ready: ['>', 'build · ', 'opencode'],
+    auth: [
+      'no provider configured',
+      'opencode auth login',
+      'missing api key',
+      'api key not found',
+      'Invalid API key',
+      '401',
+      '403',
+    ],
+    blocking: ['permission requested:', 'auto-rejecting'],
+    loading: ['> build · ', '> chat · ', '> plan · ', '> run · '],
+    turnComplete: ['Wrote file successfully.', 'Done.', 'Finished.'],
+    toolWait: ['permission requested:'],
+    exit: [],
+    source: 'baseline',
+  },
 };
 
 /**

--- a/packages/coding-agent-adapters/tests/index.test.ts
+++ b/packages/coding-agent-adapters/tests/index.test.ts
@@ -21,6 +21,7 @@ import {
   GeminiAdapter,
   HermesAdapter,
   type InstallationInfo,
+  OpencodeAdapter,
   type PreflightResult,
   printMissingAdapters,
 } from '../src/index';
@@ -69,10 +70,11 @@ describe('Exports', () => {
       expect(ADAPTER_TYPES.codex).toBe(CodexAdapter);
       expect(ADAPTER_TYPES.aider).toBe(AiderAdapter);
       expect(ADAPTER_TYPES.hermes).toBe(HermesAdapter);
+      expect(ADAPTER_TYPES.opencode).toBe(OpencodeAdapter);
     });
 
-    it('should have exactly 5 adapter types', () => {
-      expect(Object.keys(ADAPTER_TYPES)).toHaveLength(5);
+    it('should have exactly 6 adapter types', () => {
+      expect(Object.keys(ADAPTER_TYPES)).toHaveLength(6);
     });
   });
 });
@@ -111,9 +113,9 @@ describe('createAdapter()', () => {
 });
 
 describe('createAllAdapters()', () => {
-  it('should create all 5 adapters', () => {
+  it('should create all 6 adapters', () => {
     const adapters = createAllAdapters();
-    expect(adapters).toHaveLength(5);
+    expect(adapters).toHaveLength(6);
   });
 
   it('should include ClaudeAdapter', () => {
@@ -301,10 +303,10 @@ describe('checkAllAdapters()', () => {
     vi.restoreAllMocks();
   });
 
-  it('should check all 5 adapters', async () => {
+  it('should check all 6 adapters', async () => {
     const results = await checkAllAdapters();
 
-    expect(results).toHaveLength(5);
+    expect(results).toHaveLength(6);
   });
 
   it('should include all adapter names', async () => {

--- a/packages/coding-agent-adapters/tests/opencode-adapter.test.ts
+++ b/packages/coding-agent-adapters/tests/opencode-adapter.test.ts
@@ -1,0 +1,177 @@
+/**
+ * OpenCode Adapter Tests
+ */
+
+import type { SpawnConfig } from 'pty-manager';
+import { describe, expect, it } from 'vitest';
+import { OpencodeAdapter } from '../src/opencode-adapter';
+
+describe('OpencodeAdapter', () => {
+  const adapter = new OpencodeAdapter();
+
+  describe('basic properties', () => {
+    it('has correct adapter type', () => {
+      expect(adapter.adapterType).toBe('opencode');
+    });
+
+    it('has correct display name', () => {
+      expect(adapter.displayName).toBe('OpenCode');
+    });
+
+    it('uses TUI menus by default', () => {
+      expect(adapter.usesTuiMenus).toBe(true);
+    });
+
+    it('declares AGENTS.md as the auto-loaded memory file', () => {
+      const files = adapter.getWorkspaceFiles();
+      const agentsMd = files.find((f) => f.relativePath === 'AGENTS.md');
+      expect(agentsMd).toBeDefined();
+      expect(agentsMd?.autoLoaded).toBe(true);
+      expect(agentsMd?.type).toBe('memory');
+    });
+  });
+
+  describe('command/args/env', () => {
+    it('returns the opencode command', () => {
+      expect(adapter.getCommand()).toBe('opencode');
+    });
+
+    it('returns empty args in interactive mode (bare opencode TUI)', () => {
+      const args = adapter.getArgs({
+        name: 'test',
+        type: 'opencode',
+        adapterConfig: { interactive: true },
+      } as SpawnConfig);
+      expect(args).toEqual([]);
+    });
+
+    it('returns `run --dangerously-skip-permissions` in non-interactive mode', () => {
+      const args = adapter.getArgs({ name: 'test', type: 'opencode' });
+      expect(args).toEqual(['run', '--dangerously-skip-permissions']);
+    });
+
+    it('forwards OPENCODE_CONFIG_CONTENT from spawn config env into the child env', () => {
+      const env = adapter.getEnv({
+        name: 'test',
+        type: 'opencode',
+        env: {
+          OPENCODE_CONFIG_CONTENT: '{"provider":{"cerebras":{}}}',
+        },
+      } as SpawnConfig);
+      expect(env.OPENCODE_CONFIG_CONTENT).toBe(
+        '{"provider":{"cerebras":{}}}',
+      );
+    });
+
+    it('always sets OPENCODE_DISABLE_AUTOUPDATE + OPENCODE_DISABLE_TERMINAL_TITLE', () => {
+      const env = adapter.getEnv({ name: 'test', type: 'opencode' });
+      expect(env.OPENCODE_DISABLE_AUTOUPDATE).toBe('1');
+      expect(env.OPENCODE_DISABLE_TERMINAL_TITLE).toBe('1');
+    });
+
+    it('forwards ANTHROPIC_API_KEY when supplied via credentials', () => {
+      const env = adapter.getEnv({
+        name: 'test',
+        type: 'opencode',
+        adapterConfig: { anthropicKey: 'sk-ant-test' },
+      } as SpawnConfig);
+      expect(env.ANTHROPIC_API_KEY).toBe('sk-ant-test');
+    });
+
+    it('forwards OPENAI_API_KEY + OPENAI_BASE_URL when both are supplied', () => {
+      const env = adapter.getEnv({
+        name: 'test',
+        type: 'opencode',
+        adapterConfig: {
+          openaiKey: 'sk-test',
+          openaiBaseUrl: 'https://api.cerebras.ai/v1',
+        },
+      } as SpawnConfig);
+      expect(env.OPENAI_API_KEY).toBe('sk-test');
+      expect(env.OPENAI_BASE_URL).toBe('https://api.cerebras.ai/v1');
+    });
+  });
+
+  describe('detectLogin', () => {
+    it('flags missing-provider-config errors', () => {
+      const detection = adapter.detectLogin(
+        'Error: no provider configured. Run opencode auth login.',
+      );
+      expect(detection.required).toBe(true);
+      expect(detection.type).toBe('api_key');
+    });
+
+    it('flags provider-rejected credentials (401)', () => {
+      const detection = adapter.detectLogin(
+        'opencode provider error: 401 Unauthorized',
+      );
+      expect(detection.required).toBe(true);
+      expect(detection.type).toBe('api_key');
+    });
+
+    it('returns required:false for normal session output', () => {
+      const detection = adapter.detectLogin('> build · gpt-oss-120b');
+      expect(detection.required).toBe(false);
+    });
+  });
+
+  describe('detectBlockingPrompt', () => {
+    it('flags the auto-rejected permission request as a blocking prompt', () => {
+      const detection = adapter.detectBlockingPrompt(
+        '! permission requested: external_directory (/home/user/*); auto-rejecting',
+      );
+      expect(detection.detected).toBe(true);
+      expect(detection.type).toBe('permission');
+    });
+
+    it('returns detected:false for normal session output', () => {
+      const detection = adapter.detectBlockingPrompt(
+        'Wrote file successfully.',
+      );
+      expect(detection.detected).toBe(false);
+    });
+  });
+
+  describe('detectLoading', () => {
+    it('detects the active build header as loading', () => {
+      expect(adapter.detectLoading('> build · gpt-oss-120b')).toBe(true);
+    });
+
+    it('detects tool-call status lines as loading (after stripAnsi removes the arrow prefix)', () => {
+      // BaseCodingAdapter.stripAnsi strips `←` as TUI decoration, so the
+      // actual signal opencode-adapter sees is " Write /path" — leading
+      // space + verb + path. The test passes the post-stripAnsi shape.
+      expect(adapter.detectLoading(' Write /tmp/x.py')).toBe(true);
+    });
+
+    it('does not flag a terminal "Wrote file" line as loading', () => {
+      expect(adapter.detectLoading('Wrote file successfully.')).toBe(false);
+    });
+  });
+
+  describe('detectTaskComplete', () => {
+    it('flags the canonical "Wrote file successfully" line as complete', () => {
+      expect(adapter.detectTaskComplete('Wrote file successfully.')).toBe(true);
+    });
+
+    it('does not flag a still-loading session as complete', () => {
+      expect(adapter.detectTaskComplete('> build · gpt-oss-120b')).toBe(false);
+    });
+  });
+
+  describe('detectReady', () => {
+    it('detects an idle TUI prompt as ready', () => {
+      expect(adapter.detectReady('Some output\n> ')).toBe(true);
+    });
+
+    it('does not flag an active build line as ready', () => {
+      expect(adapter.detectReady('> build · gpt-oss-120b')).toBe(false);
+    });
+  });
+
+  describe('healthCheckCommand', () => {
+    it('returns the canonical opencode --version command', () => {
+      expect(adapter.getHealthCheckCommand()).toBe('opencode --version');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds OpenCode (https://opencode.ai) as a first-class adapter alongside Claude / Codex / Gemini / Aider / Hermes. OpenCode is a provider-agnostic coding agent — it speaks OpenAI's chat-completions protocol against any compatible endpoint (Anthropic, OpenAI, Cerebras, OpenRouter, Groq, Together, DeepSeek, Ollama, vLLM, plus native Anthropic). Until now downstream consumers had to bolt it onto the generic shell adapter with parallel brief-delivery and config-injection plumbing.

## What it adds

- **`OpencodeAdapter`** class (`src/opencode-adapter.ts`, ~280 lines):
  - `adapterType = 'opencode'`, `displayName = 'OpenCode'`
  - `memoryFilePath = 'AGENTS.md'` (same convention as Codex)
  - `getWorkspaceFiles()` declares AGENTS.md + opencode.json
  - `getRecommendedModels(credentials)` picks claude-opus-4-7 when Anthropic key present, gpt-4o otherwise
  - `getCommand() = 'opencode'`, `getArgs(config)` returns `['run', '--dangerously-skip-permissions', '<task>']` non-interactive (task as positional arg from `config.adapterConfig.initialPrompt`) or `[]` for the TUI
  - `getEnv(config)` forwards `OPENCODE_CONFIG_CONTENT`, `OPENCODE_DISABLE_AUTOUPDATE`, `OPENCODE_DISABLE_TERMINAL_TITLE`, plus Anthropic/OpenAI/Google keys natively
  - `detectLogin`, `detectBlockingPrompt`, `detectLoading`, `detectTaskComplete`, `detectReady`, `parseOutput`, `getPromptPattern`, `getHealthCheckCommand` — all implemented against the actual opencode 1.14.x TUI output patterns

- **Registry updates**:
  - `AdapterType` adds `'opencode'`
  - `ADAPTER_TYPES` registers `OpencodeAdapter`
  - `createAllAdapters()` returns 6 adapters now (was 5)
  - `BASELINE_PATTERNS` in `pattern-loader.ts` adds opencode entry
  - `generateApprovalConfig(adapterType, preset)` adds opencode case
  - New `generateOpencodeApprovalConfig(preset)` (only `autonomous` adds `--dangerously-skip-permissions`; others stay interactive)

- **24 new shape tests** in `tests/opencode-adapter.test.ts` covering basic properties, command/args/env, login detection, blocking prompts, loading/ready/complete state, health check
- **3 existing index.test.ts tests updated** for the 6-adapter count
- **Full package suite: 689/689 tests pass**

## Downstream impact

Callers that previously routed opencode through the shell adapter can now call `getAdapter('opencode')` like any other adapter and delete the parallel plumbing. First downstream is milady ([elizaOS/eliza#7609](https://github.com/elizaOS/eliza/pull/7609), merged into develop) — its orchestrator's `normalizeAgentType` now routes opencode to the canonical type when this adapter is present.

Live verification (milady running on Cerebras gpt-oss-120b via the auto-detected `CEREBRAS_API_KEY` path):
```
[PTYService] OpenCode spawn provider: Cerebras (auto-detected from CEREBRAS_API_KEY) (model=cerebras/llama-3.3-70b)
Spawning session { type: 'opencode', name: 'agent-1778578801375' }
[PTYService] Spawned session pty-1778578801379-568304a0 (opencode)
```

## Test plan

- [x] `pnpm build` — clean (TypeScript declarations + CJS + ESM)
- [x] `pnpm vitest run` — 689/689 tests pass
- [x] Live integration via milady — preflight reports `{adapter: "OpenCode", installed: true, version: "1.14.48"}`
- [x] Spawn cycle observed in PTY logs against Cerebras gpt-oss-120b