### PR TITLE
fix: persist gateway thread events and final status

### DIFF
--- a/packages/control-plane/src/agent-runtime/__tests__/gateway-runtime-adapter.test.ts
+++ b/packages/control-plane/src/agent-runtime/__tests__/gateway-runtime-adapter.test.ts
@@ -358,17 +358,103 @@ describe('GatewayRuntimeAdapter', () => {
       );
     });
 
-    it('should update thread status to completed after stop', async () => {
+    it('should update thread status to stopped and emit a stopped event after stop', async () => {
       const session = createMockSession({ agentId: 'pi-1' });
       const agents = new Map([['pi-1', session]]);
       const gateway = createMockGateway(agents);
       const adapter = new GatewayRuntimeAdapter(logger, gateway);
 
+      const emitted: Array<{ event: any; thread: any }> = [];
+      adapter.on('thread_event', (data) => emitted.push(data));
+
       await adapter.spawnThread(createSpawnInput({ id: 'thread-cs' }));
       await adapter.stopThread('thread-cs');
 
       const thread = await adapter.getThread('thread-cs');
+      expect(thread?.status).toBe('stopped');
+
+      const stopEvent = emitted.find((e) => e.event.type === 'thread_stopped');
+      expect(stopEvent).toBeDefined();
+      expect(stopEvent!.event.threadId).toBe('thread-cs');
+      expect(stopEvent!.thread.status).toBe('stopped');
+    });
+  });
+
+  describe('gateway event normalization', () => {
+    function adapterWithCapturedSubscriber() {
+      const session = createMockSession({ agentId: 'pi-1' });
+      const agents = new Map([['pi-1', session]]);
+      const gateway = createMockGateway(agents);
+      let subscriber: ((event: any) => void) | undefined;
+      (gateway.subscribeThreadEvents as any).mockImplementation(
+        (_threadId: string, cb: (event: any) => void) => {
+          subscriber = cb;
+          return vi.fn();
+        }
+      );
+      const adapter = new GatewayRuntimeAdapter(logger, gateway);
+      return { adapter, getSubscriber: () => subscriber };
+    }
+
+    it('translates raw gateway events into runtime-interface ThreadEvents', async () => {
+      const { adapter, getSubscriber } = adapterWithCapturedSubscriber();
+      const emitted: Array<{ event: any; thread: any }> = [];
+      adapter.on('thread_event', (data) => emitted.push(data));
+
+      await adapter.spawnThread(createSpawnInput({ id: 'thread-ev' }));
+
+      getSubscriber()!({
+        thread_id: 'thread-ev',
+        event_type: 'output',
+        data_json: JSON.stringify({ text: 'hello' }),
+        timestamp_ms: 1700000000000,
+        sequence: 3,
+      });
+
+      expect(emitted).toHaveLength(1);
+      const { event, thread } = emitted[0];
+      expect(event.threadId).toBe('thread-ev');
+      expect(event.executionId).toBe('exec-1');
+      expect(event.type).toBe('thread_output');
+      expect(event.timestamp).toEqual(new Date(1700000000000));
+      expect(event.data).toMatchObject({ text: 'hello', sequence: 3 });
+      expect(thread.status).toBe('running');
+    });
+
+    it('moves the handle to a terminal status on completed/failed events', async () => {
+      const { adapter, getSubscriber } = adapterWithCapturedSubscriber();
+
+      await adapter.spawnThread(createSpawnInput({ id: 'thread-term' }));
+
+      getSubscriber()!({
+        thread_id: 'thread-term',
+        event_type: 'completed',
+        data_json: '',
+        timestamp_ms: Date.now(),
+        sequence: 1,
+      });
+
+      const thread = await adapter.getThread('thread-term');
       expect(thread?.status).toBe('completed');
+    });
+
+    it('preserves unparseable data_json as raw payload', async () => {
+      const { adapter, getSubscriber } = adapterWithCapturedSubscriber();
+      const emitted: Array<{ event: any }> = [];
+      adapter.on('thread_event', (data) => emitted.push(data));
+
+      await adapter.spawnThread(createSpawnInput({ id: 'thread-raw' }));
+
+      getSubscriber()!({
+        thread_id: 'thread-raw',
+        event_type: 'output',
+        data_json: 'not-json',
+        timestamp_ms: 0,
+        sequence: 0,
+      });
+
+      expect(emitted[0].event.data).toMatchObject({ raw: 'not-json' });
+      expect(emitted[0].event.timestamp).toBeInstanceOf(Date);
     });
   });
 

--- a/packages/control-plane/src/agent-runtime/gateway-runtime-adapter.ts
+++ b/packages/control-plane/src/agent-runtime/gateway-runtime-adapter.ts
@@ -120,11 +120,74 @@ export class GatewayRuntimeAdapter extends EventEmitter {
     }
   > = new Map();
 
+  /** Gateway events whose arrival moves the thread to a terminal status. */
+  private static readonly TERMINAL_EVENT_STATUS: Partial<
+    Record<ThreadEvent['type'], ThreadStatus>
+  > = {
+    thread_completed: 'completed',
+    thread_failed: 'failed',
+    thread_stopped: 'stopped',
+  };
+
   constructor(
     private logger: Logger,
     private gateway: GatewayServiceAdapter
   ) {
     super();
+  }
+
+  /**
+   * Normalize a raw gateway ThreadEventReport ({thread_id, event_type,
+   * data_json, timestamp_ms, sequence}) into a runtime-interface ThreadEvent.
+   * Persistence and downstream consumers expect the normalized shape — raw
+   * gateway events fail the thread_events insert (no threadId/type).
+   */
+  private translateGatewayEvent(
+    handle: ThreadHandle,
+    raw: {
+      event_type?: string;
+      data_json?: string;
+      timestamp_ms?: number | string;
+      sequence?: number;
+    }
+  ): ThreadEvent {
+    const rawType = String(raw?.event_type || 'output');
+    const type = (
+      rawType.startsWith('thread_') ? rawType : `thread_${rawType}`
+    ) as ThreadEvent['type'];
+
+    let data: Record<string, unknown> | undefined;
+    if (raw?.data_json) {
+      try {
+        data = JSON.parse(raw.data_json) as Record<string, unknown>;
+      } catch {
+        data = { raw: raw.data_json };
+      }
+    }
+
+    const ts = Number(raw?.timestamp_ms);
+    return {
+      threadId: handle.id,
+      executionId: handle.executionId,
+      type,
+      timestamp: Number.isFinite(ts) && ts > 0 ? new Date(ts) : new Date(),
+      data: { ...(data ?? {}), sequence: raw?.sequence ?? 0 },
+    };
+  }
+
+  /** Translate a raw gateway event, sync the handle, and emit for persistence. */
+  private forwardGatewayEvent(
+    handle: ThreadHandle,
+    raw: Parameters<GatewayRuntimeAdapter['translateGatewayEvent']>[1]
+  ): void {
+    const event = this.translateGatewayEvent(handle, raw);
+    const terminalStatus =
+      GatewayRuntimeAdapter.TERMINAL_EVENT_STATUS[event.type];
+    if (terminalStatus) {
+      handle.status = terminalStatus;
+    }
+    handle.updatedAt = event.timestamp;
+    this.emit('thread_event', { event, thread: handle });
   }
 
   // ─── RuntimeClient-compatible interface ───
@@ -202,9 +265,9 @@ export class GatewayRuntimeAdapter extends EventEmitter {
 
     this.threads.set(threadId, { handle, gatewayAgentId: agentId });
 
-    // Forward thread events from gateway
+    // Forward thread events from gateway, normalized for persistence
     this.gateway.subscribeThreadEvents(threadId, (event) => {
-      this.emit('thread_event', { event, thread: handle });
+      this.forwardGatewayEvent(handle, event);
     });
 
     return handle;
@@ -223,8 +286,20 @@ export class GatewayRuntimeAdapter extends EventEmitter {
       force: options?.force,
     });
 
-    info.handle.status = 'completed' as ThreadStatus;
+    // Emit a synthetic stopped event so persistence records the final status —
+    // the agent's own status update arrives after we may have unsubscribed.
+    info.handle.status = 'stopped' as ThreadStatus;
     info.handle.updatedAt = new Date();
+    this.emit('thread_event', {
+      event: {
+        threadId,
+        executionId: info.handle.executionId,
+        type: 'thread_stopped',
+        timestamp: info.handle.updatedAt,
+        data: { reason: 'stop_requested', force: options?.force ?? false },
+      } satisfies ThreadEvent,
+      thread: info.handle,
+    });
   }
 
   async getThread(threadId: string): Promise<ThreadHandle | null> {

--- a/packages/control-plane/src/grpc/services/gateway-service.ts
+++ b/packages/control-plane/src/grpc/services/gateway-service.ts
@@ -707,23 +707,10 @@ export class GatewayService extends EventEmitter {
           { agentId, threadId, reason },
           'Thread failed due to agent disconnect'
         );
-        if (this.executionEvents) {
-          this.executionEvents.emitEvent({
-            executionId: threadId,
-            type: 'gateway_thread_failed',
-            data: {
-              thread_id: threadId,
-              event_type: 'failed',
-              data_json: JSON.stringify({
-                reason: `Agent disconnected: ${reason}`,
-              }),
-              timestamp_ms: Date.now(),
-              sequence: 0,
-            },
-            timestamp: new Date(),
-          });
-        }
-        this.emit('thread_event', {
+        // Route through the normal event path so per-thread subscribers
+        // (runtime adapter → persistence) see the failure, not just the
+        // execution event bus.
+        this.handleThreadEvent({
           thread_id: threadId,
           event_type: 'failed',
           data_json: JSON.stringify({


### PR DESCRIPTION
## Summary
- Gateway threads had **no persisted events** (`GET /api/managed-threads/:id/events` always empty): the gateway runtime adapter forwarded raw wire events (`{thread_id, event_type, data_json}`) while `ThreadRepository.recordRuntimeProjection` expects the runtime-interface `ThreadEvent` shape (`{threadId, executionId, type, timestamp}`), so every `thread_events` insert failed silently. The adapter now normalizes events (`output` → `thread_output`, etc.) before emitting.
- Thread DB status stayed `running` forever after a stop: `stopThread` only mutated the in-memory handle. It now emits a synthetic `thread_stopped` event so persistence records the terminal status (and the handle is marked `stopped`, not `completed`).
- Agent-disconnect failures now route through `handleThreadEvent` so per-thread subscribers (adapter → persistence) observe them instead of only the execution event bus.

Both symptoms were observed live against the deployed control plane (thread `6145dd06` on 2026-07-19).

## Test plan
- [x] 3 new adapter tests covering event normalization, terminal-status transitions, and unparseable payloads
- [x] `packages/control-plane`: full vitest suite 252/252 passing, `tsc --noEmit` clean
- [ ] Post-deploy: re-run gateway smoke test (spawn → events populated → stop → status `stopped`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpPD79CZQS8p3bPDrdVXdn