### PR TITLE
fix(ci): sync pty-manager specifier to ^1.12.1 in package manifests

### DIFF
--- a/demos/pty-console-agent-containers/package.json
+++ b/demos/pty-console-agent-containers/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "coding-agent-adapters": "^0.17.0",
     "pty-console": "^0.3.2",
-    "pty-manager": "^1.12.0"
+    "pty-manager": "^1.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.1",

--- a/packages/parallax-agent-runtime/package.json
+++ b/packages/parallax-agent-runtime/package.json
@@ -27,7 +27,7 @@
     "jsonwebtoken": "^9.0.0",
     "pino": "^9.5.0",
     "pino-pretty": "^13.0.0",
-    "pty-manager": "^1.12.0",
+    "pty-manager": "^1.12.1",
     "uuid": "^11.0.5",
     "zod": "^3.25.0"
   },

--- a/packages/runtime-local/package.json
+++ b/packages/runtime-local/package.json
@@ -23,7 +23,7 @@
     "express": "^4.21.2",
     "pino": "^9.5.0",
     "pino-pretty": "^13.0.0",
-    "pty-manager": "^1.12.0",
+    "pty-manager": "^1.12.1",
     "ws": "^8.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
c2aad30 bumped pty-manager to 1.12.1 in pnpm-lock.yaml but left three package.json manifests at ^1.12.0. Every `pnpm install --frozen-lockfile` in CI has failed since (ERR_PNPM_OUTDATED_LOCKFILE), so no images have been built from main since May — prod is still running the May-14 build.

Verified locally: `pnpm install --frozen-lockfile --lockfile-only` passes with these three bumps.

Unblocks the build for #45 (gateway thread persistence fix) and the pending production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpPD79CZQS8p3bPDrdVXdn