### PR TITLE
fix(docker): copy pruned packages tree instead of hardcoded list

### DIFF
--- a/packages/control-plane/Dockerfile
+++ b/packages/control-plane/Dockerfile
@@ -52,16 +52,10 @@ RUN addgroup -g 1001 -S parallax && \
 # The .pnpm store in root node_modules is the source of truth
 COPY --from=builder /app/node_modules ./node_modules
 
-# Copy packages with their local node_modules (symlinks to .pnpm)
-COPY --from=builder /app/packages/control-plane ./packages/control-plane
-COPY --from=builder /app/packages/runtime ./packages/runtime
-COPY --from=builder /app/packages/telemetry ./packages/telemetry
-COPY --from=builder /app/packages/sdk-typescript ./packages/sdk-typescript
-COPY --from=builder /app/packages/security ./packages/security
-COPY --from=builder /app/packages/data-plane ./packages/data-plane
-COPY --from=builder /app/packages/runtime-interface ./packages/runtime-interface
-COPY --from=builder /app/packages/git-workspace-service ./packages/git-workspace-service
-COPY --from=builder /app/packages/auth ./packages/auth
+# Copy all pruned workspace packages with their local node_modules
+# (symlinks to .pnpm). turbo prune already scoped this to control-plane's
+# dependency graph, so a hardcoded list only drifts as deps change.
+COPY --from=builder /app/packages ./packages
 
 # Copy proto files for gRPC
 COPY --from=pruner /app/proto ./proto


### PR DESCRIPTION
The control-plane image build has been failing at the production stage: it copies `packages/git-workspace-service` and `packages/auth`, which left the workspace during the M0-M3 refactor (git-workspace-service is now an external npm dep). It also never copied the new `confidence` and `patterns` packages, so even a successful build would fail at runtime.

`turbo prune @parallaxai/control-plane --docker` already scopes `/app/packages` in the builder to exactly the dependency graph (verified locally: confidence, control-plane, data-plane, patterns, runtime, runtime-interface, sdk-typescript, security, telemetry), so the production stage now copies the whole tree instead of a drifting hardcoded list.

Unblocks the control-plane image for #45. web-dashboard and runtime-k8s images already build green after #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpPD79CZQS8p3bPDrdVXdn