### PR TITLE
fix(helm): always render patterns configmap the deployment mounts

### DIFF
--- a/k8s/helm/parallax/templates/control-plane-deployment.yaml
+++ b/k8s/helm/parallax/templates/control-plane-deployment.yaml
@@ -177,6 +177,7 @@ spec:
         - name: patterns
           configMap:
             name: {{ .Values.controlPlane.patterns.configMap }}
+            optional: true
         - name: config
           configMap:
             name: {{ include "parallax.fullname" . }}-control-plane

--- a/k8s/helm/parallax/templates/patterns-configmap.yaml
+++ b/k8s/helm/parallax/templates/patterns-configmap.yaml
@@ -1,4 +1,9 @@
-{{- if .Values.controlPlane.patterns.defaultPatterns }}
+{{- /*
+Always render this configmap: the control-plane deployment mounts it
+unconditionally at /patterns. Rendering it only when defaultPatterns is
+set caused helm to delete it on upgrade, leaving new pods stuck in
+Init with an unmountable volume.
+*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,4 +17,3 @@ data:
   {{ $name }}: |
 {{ $content | indent 4 }}
   {{- end }}
-{{- end }}


### PR DESCRIPTION
Fixes the failed auto-deploy (run 29772734209, `UPGRADE FAILED: context deadline exceeded`).

The control-plane deployment mounts the `parallax-patterns` configmap unconditionally, but `patterns-configmap.yaml` only rendered when `controlPlane.patterns.defaultPatterns` was non-empty — it's `{}`, so the previous upgrade **deleted** the configmap out from under the deployment. That upgrade's pod won the mount race and started; the next one lost it and sat in `Init:0/2` until helm's `--wait` timed out (`FailedMount: configmap "parallax-patterns" not found`).

- render the configmap unconditionally (empty `data:` is valid)
- add `optional: true` to the volume so a missing configmap can never wedge a rollout again

Verified with `helm lint` + `helm template`: configmap renders with empty defaultPatterns, volume carries `optional: true`. The currently-serving pod is unaffected; merging will roll out cleanly and replace the stuck pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpPD79CZQS8p3bPDrdVXdn